### PR TITLE
perform synchronous calls concurrently with main loop

### DIFF
--- a/go/potoo/mqtt/wrappers/pahowrapper/wrapper.go
+++ b/go/potoo/mqtt/wrappers/pahowrapper/wrapper.go
@@ -60,13 +60,9 @@ func (p *Wrapper) handleMessage(_client paho.Client, pahoMsg paho.Message) {
 		Retain:  retained,
 	}
 
-	// we use a goroutine here just to be safe (paho doesn't like its handler to block)
-	// maybe a buffered channel would be better?
-	go func() {
-		if p.connConf.OnMessage != nil {
-			p.connConf.OnMessage <- msg
-		}
-	}()
+	if p.connConf.OnMessage != nil {
+		p.connConf.OnMessage <- msg
+	}
 }
 
 func (p *Wrapper) Publish(m mqtt.Message) {

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -33,12 +33,12 @@ type Connection struct {
 
 	contractTopic mqtt.Topic
 
-	mqttDisconnect chan error
-	mqttMessage    chan mqtt.Message
-	updateContract chan contracts.Contract
-	outgoingValues chan outgoingValue
-	callResults    chan callResult
-	syncCalls      chan func()
+	mqttDisconnect   chan error
+	mqttMessage      chan mqtt.Message
+	updateContract   chan contracts.Contract
+	outgoingValues   chan outgoingValue
+	finalCallResults chan finalCallResult
+	syncCalls        chan func()
 
 	serviceCallableIndex map[string]*contracts.Callable
 	unsubscribers        []func()
@@ -68,7 +68,7 @@ func New(opts *ConnectionOptions) *Connection {
 	c.mqttMessage = make(chan mqtt.Message, opts.MQTTBacklogSize)
 	c.updateContract = make(chan contracts.Contract)
 	c.outgoingValues = make(chan outgoingValue)
-	c.callResults = make(chan callResult)
+	c.finalCallResults = make(chan finalCallResult)
 	c.syncCalls = make(chan func(), opts.MQTTBacklogSize)
 
 	c.serviceCallableIndex = make(map[string]*contracts.Callable)
@@ -172,7 +172,7 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 			if err != nil {
 				return fmt.Errorf("Unable to send value: %s", err)
 			}
-		case result := <-c.callResults:
+		case result := <-c.finalCallResults:
 			err = c.finaliseAsyncCall(result)
 			if err != nil {
 				return fmt.Errorf("Error during async call: %s", err)
@@ -317,7 +317,7 @@ func (c *Connection) handleCall(msg mqtt.Message, callable *contracts.Callable) 
 			return
 		}
 
-		c.callResults <- callResult{
+		c.finalCallResults <- finalCallResult{
 			callResult: result,
 			arena:      arena,
 			parser:     parser,
@@ -332,7 +332,7 @@ func (c *Connection) handleCall(msg mqtt.Message, callable *contracts.Callable) 
 	return nil
 }
 
-func (c *Connection) finaliseAsyncCall(result callResult) error {
+func (c *Connection) finaliseAsyncCall(result finalCallResult) error {
 	defer c.parserPool.Put(result.parser)
 	defer c.arenaPool.Put(result.arena)
 	defer result.arena.Reset() // TODO: see if we really need this
@@ -352,7 +352,7 @@ func (c *Connection) finaliseCall(result callResult) error {
 	return nil
 }
 
-type callResult struct {
+type finalCallResult struct {
 	callResult
 
 	arena  *fastjson.Arena
@@ -502,7 +502,7 @@ func (c *Connection) closeOutgoingValues() {
 }
 
 func (c *Connection) closeAsyncCalls() {
-	ch := c.callResults
+	ch := c.finalCallResults
 
 	defer close(ch)
 

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -14,11 +14,12 @@ import (
 )
 
 type ConnectionOptions struct {
-	MqttClient  mqtt.Client
-	Root        mqtt.Topic
-	ServiceRoot mqtt.Topic
-	OnContract  func(mqtt.Topic, contracts.Contract)
-	CallTimeout time.Duration
+	MqttClient      mqtt.Client
+	Root            mqtt.Topic
+	ServiceRoot     mqtt.Topic
+	OnContract      func(mqtt.Topic, contracts.Contract)
+	CallTimeout     time.Duration
+	MQTTBacklogSize uint16
 }
 
 type Connection struct {

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -142,41 +142,40 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 		}
 	}()
 
-	go func() {
+	go func() error {
 		for {
 			select {
-			case contract := <-c.updateContract:
-				err = c.handleUpdateContract(contract)
+			case err = <-c.mqttDisconnect:
 				if err != nil {
-					// TODO: should we crash like this, or use c.err()?
-					return fmt.Errorf("Unable to update contract: %s", err)
+					return fmt.Errorf("MQTT error: %s", err)
 				}
-			case ov := <-c.outgoingValues:
-				err = c.handleOutgoingValue(ov)
-				if err != nil {
-					return fmt.Errorf("Unable to send value: %s", err)
-				}
-			case result := <-c.asyncCallResults:
-				err = c.finaliseAsyncCall(result)
-				if err != nil {
-					return fmt.Errorf("Error during async call: %s", err)
-				}
+				return nil
+			case <-exit:
+				return nil
+			case msg := <-c.mqttMessage:
+				c.handleMsg(msg)
 			}
-			c.arena.Reset()
 		}
 	}()
 
 	for {
 		select {
-		case err = <-c.mqttDisconnect:
+		case contract := <-c.updateContract:
+			err = c.handleUpdateContract(contract)
 			if err != nil {
-				return fmt.Errorf("MQTT error: %s", err)
+				// TODO: should we crash like this, or use c.err()?
+				return fmt.Errorf("Unable to update contract: %s", err)
 			}
-			return nil
-		case <-exit:
-			return nil
-		case msg := <-c.mqttMessage:
-			c.handleMsg(msg)
+		case ov := <-c.outgoingValues:
+			err = c.handleOutgoingValue(ov)
+			if err != nil {
+				return fmt.Errorf("Unable to send value: %s", err)
+			}
+		case result := <-c.asyncCallResults:
+			err = c.finaliseAsyncCall(result)
+			if err != nil {
+				return fmt.Errorf("Error during async call: %s", err)
+			}
 		}
 		c.arena.Reset()
 	}

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -149,11 +149,12 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 				if err != nil {
 					return fmt.Errorf("MQTT error: %s", err)
 				}
-				return nil
-			case <-exit:
-				return nil
 			case msg := <-c.mqttMessage:
 				c.handleMsg(msg)
+			case <-exit:
+				return nil
+			case _ = <-c.thatsAllFolks:
+				return nil
 			}
 		}
 	}()
@@ -176,6 +177,10 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 			if err != nil {
 				return fmt.Errorf("Error during async call: %s", err)
 			}
+		case <-exit:
+			return nil
+		case _ = <-c.thatsAllFolks:
+			return nil
 		}
 		c.arena.Reset()
 	}

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -142,6 +142,30 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 		}
 	}()
 
+	go func() {
+		for {
+			select {
+			case contract := <-c.updateContract:
+				err = c.handleUpdateContract(contract)
+				if err != nil {
+					// TODO: should we crash like this, or use c.err()?
+					return fmt.Errorf("Unable to update contract: %s", err)
+				}
+			case ov := <-c.outgoingValues:
+				err = c.handleOutgoingValue(ov)
+				if err != nil {
+					return fmt.Errorf("Unable to send value: %s", err)
+				}
+			case result := <-c.asyncCallResults:
+				err = c.finaliseAsyncCall(result)
+				if err != nil {
+					return fmt.Errorf("Error during async call: %s", err)
+				}
+			}
+			c.arena.Reset()
+		}
+	}()
+
 	for {
 		select {
 		case err = <-c.mqttDisconnect:
@@ -153,22 +177,6 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 			return nil
 		case msg := <-c.mqttMessage:
 			c.handleMsg(msg)
-		case contract := <-c.updateContract:
-			err = c.handleUpdateContract(contract)
-			if err != nil {
-				// TODO: should we crash like this, or use c.err()?
-				return fmt.Errorf("Unable to update contract: %s", err)
-			}
-		case ov := <-c.outgoingValues:
-			err = c.handleOutgoingValue(ov)
-			if err != nil {
-				return fmt.Errorf("Unable to send value: %s", err)
-			}
-		case result := <-c.asyncCallResults:
-			err = c.finaliseAsyncCall(result)
-			if err != nil {
-				return fmt.Errorf("Error during async call: %s", err)
-			}
 		}
 		c.arena.Reset()
 	}

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -32,11 +32,12 @@ type Connection struct {
 
 	contractTopic mqtt.Topic
 
-	mqttDisconnect chan error
-	mqttMessage    chan mqtt.Message
-	updateContract chan contracts.Contract
-	outgoingValues chan outgoingValue
-	asyncCalls     chan asyncCallResult
+	mqttDisconnect   chan error
+	mqttMessage      chan mqtt.Message
+	updateContract   chan contracts.Contract
+	outgoingValues   chan outgoingValue
+	asyncCallResults chan asyncCallResult
+	syncCalls        chan func()
 
 	serviceCallableIndex map[string]*contracts.Callable
 	unsubscribers        []func()
@@ -58,11 +59,16 @@ func New(opts *ConnectionOptions) *Connection {
 
 	c.contractTopic = c.serviceTopic(mqtt.Topic("_contract"))
 
+	if opts.MQTTBacklogSize == 0 {
+		panic("MQTTBacklogSize should not be zero")
+	}
+
 	c.mqttDisconnect = make(chan error)
-	c.mqttMessage = make(chan mqtt.Message)
+	c.mqttMessage = make(chan mqtt.Message, opts.MQTTBacklogSize)
 	c.updateContract = make(chan contracts.Contract)
 	c.outgoingValues = make(chan outgoingValue)
-	c.asyncCalls = make(chan asyncCallResult)
+	c.asyncCallResults = make(chan asyncCallResult)
+	c.syncCalls = make(chan func(), opts.MQTTBacklogSize)
 
 	c.serviceCallableIndex = make(map[string]*contracts.Callable)
 
@@ -109,6 +115,7 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 		go c.closeOutgoingValues()
 		go c.closeAsyncCalls()
 		c.deathMutex.Lock()
+		close(c.syncCalls)
 		close(c.thatsAllFolks)
 		c.deathMutex.Unlock()
 		c.destroyService()
@@ -127,6 +134,12 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 	}
 
 	defer c.opts.MqttClient.DisconnectWithWill()
+
+	go func() {
+		for call := range c.syncCalls {
+			call()
+		}
+	}()
 
 	for {
 		select {
@@ -150,7 +163,7 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 			if err != nil {
 				return fmt.Errorf("Unable to send value: %s", err)
 			}
-		case result := <-c.asyncCalls:
+		case result := <-c.asyncCallResults:
 			err = c.finaliseAsyncCall(result)
 			if err != nil {
 				return fmt.Errorf("Error during async call: %s", err)
@@ -278,28 +291,30 @@ func (c *Connection) msg(topic mqtt.Topic, payload *fastjson.Value, retain bool,
 
 // TODO: async calls (some way for the handler to return a channel which will be read later?)
 func (c *Connection) handleCall(msg mqtt.Message, callable *contracts.Callable) error {
+	call := func() {
+		arena := c.arenaPool.Get()
+		parser := c.parserPool.Get()
+		result := handleCallHelper(arena, parser, msg, callable)
+
+		c.deathMutex.Lock()
+		defer c.deathMutex.Unlock()
+		if c.dead {
+			// the potoo service died while handling the call, there
+			// is noone to return the result to
+			return
+		}
+
+		c.asyncCallResults <- asyncCallResult{
+			callResult: result,
+			arena:      arena,
+			parser:     parser,
+		}
+	}
+
 	if callable.Async == false {
-		return c.finaliseCall(handleCallHelper(c.arena, c.jsonparser, msg, callable))
+		c.syncCalls <- call
 	} else {
-		go func() {
-			arena := c.arenaPool.Get()
-			parser := c.parserPool.Get()
-			result := handleCallHelper(arena, parser, msg, callable)
-
-			c.deathMutex.Lock()
-			defer c.deathMutex.Unlock()
-			if c.dead {
-				// the potoo service died while handling the call, there
-				// is noone to return the result to
-				return
-			}
-
-			c.asyncCalls <- asyncCallResult{
-				callResult: result,
-				arena:      arena,
-				parser:     parser,
-			}
-		}()
+		go call()
 	}
 	return nil
 }
@@ -474,7 +489,7 @@ func (c *Connection) closeOutgoingValues() {
 }
 
 func (c *Connection) closeAsyncCalls() {
-	ch := c.asyncCalls
+	ch := c.asyncCallResults
 
 	defer close(ch)
 

--- a/go/potoo/potoo.go
+++ b/go/potoo/potoo.go
@@ -33,12 +33,12 @@ type Connection struct {
 
 	contractTopic mqtt.Topic
 
-	mqttDisconnect   chan error
-	mqttMessage      chan mqtt.Message
-	updateContract   chan contracts.Contract
-	outgoingValues   chan outgoingValue
-	asyncCallResults chan asyncCallResult
-	syncCalls        chan func()
+	mqttDisconnect chan error
+	mqttMessage    chan mqtt.Message
+	updateContract chan contracts.Contract
+	outgoingValues chan outgoingValue
+	callResults    chan callResult
+	syncCalls      chan func()
 
 	serviceCallableIndex map[string]*contracts.Callable
 	unsubscribers        []func()
@@ -68,7 +68,7 @@ func New(opts *ConnectionOptions) *Connection {
 	c.mqttMessage = make(chan mqtt.Message, opts.MQTTBacklogSize)
 	c.updateContract = make(chan contracts.Contract)
 	c.outgoingValues = make(chan outgoingValue)
-	c.asyncCallResults = make(chan asyncCallResult)
+	c.callResults = make(chan callResult)
 	c.syncCalls = make(chan func(), opts.MQTTBacklogSize)
 
 	c.serviceCallableIndex = make(map[string]*contracts.Callable)
@@ -172,7 +172,7 @@ func (c *Connection) Loop(exit <-chan struct{}) error {
 			if err != nil {
 				return fmt.Errorf("Unable to send value: %s", err)
 			}
-		case result := <-c.asyncCallResults:
+		case result := <-c.callResults:
 			err = c.finaliseAsyncCall(result)
 			if err != nil {
 				return fmt.Errorf("Error during async call: %s", err)
@@ -317,7 +317,7 @@ func (c *Connection) handleCall(msg mqtt.Message, callable *contracts.Callable) 
 			return
 		}
 
-		c.asyncCallResults <- asyncCallResult{
+		c.callResults <- callResult{
 			callResult: result,
 			arena:      arena,
 			parser:     parser,
@@ -332,7 +332,7 @@ func (c *Connection) handleCall(msg mqtt.Message, callable *contracts.Callable) 
 	return nil
 }
 
-func (c *Connection) finaliseAsyncCall(result asyncCallResult) error {
+func (c *Connection) finaliseAsyncCall(result callResult) error {
 	defer c.parserPool.Put(result.parser)
 	defer c.arenaPool.Put(result.arena)
 	defer result.arena.Reset() // TODO: see if we really need this
@@ -352,7 +352,7 @@ func (c *Connection) finaliseCall(result callResult) error {
 	return nil
 }
 
-type asyncCallResult struct {
+type callResult struct {
 	callResult
 
 	arena  *fastjson.Arena
@@ -502,7 +502,7 @@ func (c *Connection) closeOutgoingValues() {
 }
 
 func (c *Connection) closeAsyncCalls() {
-	ch := c.asyncCallResults
+	ch := c.callResults
 
 	defer close(ch)
 


### PR DESCRIPTION
Currently, synchronous calls are handled in the main potoo loop while async calls are fired off in a goroutine.

In practice, this makes sync calls almost useless, because sending anything on a potoo bus from inside a sync call results in a deadlock. Async calls, however, are also not optimal for all cases because they are not ordered.

So, we make sync calls be performed in the background but in an ordered fashion, while retaining fully-async functionality for cases where we need real parallelism.

Also, we move the incoming MQTT traffic in a separate goroutine from the outgoing MQTT traffic to avoid result sending waiting for requests processing